### PR TITLE
Remove clients rpcbuffer

### DIFF
--- a/iguagile/client.go
+++ b/iguagile/client.go
@@ -7,6 +7,5 @@ type Client interface {
 	SendToAllClients([]byte)
 	SendToOtherClients([]byte)
 	CloseConnection()
-	AddBuffer(*[]byte)
 	GetID() []byte
 }

--- a/iguagile/room.go
+++ b/iguagile/room.go
@@ -72,6 +72,7 @@ func (r *Room) Register(client Client) {
 	r.buffer[&message] = client
 }
 
+// Unregister requests from clients.
 func (r *Room) Unregister(client Client) {
 	for message, c := range r.buffer {
 		if c == client {

--- a/iguagile/tcp-client.go
+++ b/iguagile/tcp-client.go
@@ -10,11 +10,10 @@ import (
 
 // ClientTCP is a middleman between the tcp connection and the room.
 type ClientTCP struct {
-	id     []byte
-	conn   *net.TCPConn
-	room   *Room
-	buffer []*[]byte
-	send   chan []byte
+	id   []byte
+	conn *net.TCPConn
+	room *Room
+	send chan []byte
 }
 
 // NewClientTCP is ClientTCP constructed.
@@ -104,17 +103,8 @@ func (c *ClientTCP) SendToOtherClients(message []byte) {
 func (c *ClientTCP) CloseConnection() {
 	message := append(c.id, exitConnection)
 	c.SendToOtherClients(message)
-	for _, message := range c.buffer {
-		delete(c.room.buffer, message)
-	}
-	delete(c.room.clients, c)
+	c.room.Unregister(c)
 	if err := c.conn.Close(); err != nil {
 		c.room.log.Println(err)
 	}
-}
-
-// AddBuffer is buffer messages
-func (c *ClientTCP) AddBuffer(message *[]byte) {
-	c.buffer = append(c.buffer, message)
-	c.room.buffer[message] = true
 }

--- a/iguagile/websocket-client.go
+++ b/iguagile/websocket-client.go
@@ -10,11 +10,10 @@ import (
 
 // ClientWebsocket is a middleman between the websocket connection and the room.
 type ClientWebsocket struct {
-	id     []byte
-	conn   *websocket.Conn
-	room   *Room
-	buffer []*[]byte
-	send   chan []byte
+	id   []byte
+	conn *websocket.Conn
+	room *Room
+	send chan []byte
 }
 
 // NewClientWebsocket is ClientWebsocket constructed.
@@ -67,19 +66,10 @@ func (c *ClientWebsocket) SendToOtherClients(message []byte) {
 func (c *ClientWebsocket) CloseConnection() {
 	message := append(c.id, exitConnection)
 	c.SendToOtherClients(message)
-	for _, message := range c.buffer {
-		delete(c.room.buffer, message)
-	}
-	delete(c.room.clients, c)
+	c.room.Unregister(c)
 	if err := c.conn.Close(); err != nil {
 		c.room.log.Println(err)
 	}
-}
-
-// AddBuffer is buffer messages
-func (c *ClientWebsocket) AddBuffer(message *[]byte) {
-	c.buffer = append(c.buffer, message)
-	c.room.buffer[message] = true
 }
 
 // Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.


### PR DESCRIPTION
切断時にバッファを削除するためにClient自身がバッファしたメッセージを記憶しておかなくても済むようにRoomが持っているバッファのハッシュテーブルの値をClientに変更