### PR TITLE
Refactor

### DIFF
--- a/iguagile/client.go
+++ b/iguagile/client.go
@@ -4,9 +4,7 @@ package iguagile
 type Client interface {
 	Run()
 	Send([]byte)
-	SendToAllClients([]byte)
-	SendToOtherClients([]byte)
-	CloseConnection()
 	GetID() int
 	GetIDByte() []byte
+	Close() error
 }

--- a/iguagile/websocket-client.go
+++ b/iguagile/websocket-client.go
@@ -1,6 +1,7 @@
 package iguagile
 
 import (
+	"encoding/binary"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -18,16 +19,16 @@ type ClientWebsocket struct {
 // NewClientWebsocket is ClientWebsocket constructed.
 func NewClientWebsocket(room *Room, conn *websocket.Conn) (*ClientWebsocket, error) {
 	id, err := room.generator.Generate()
+	idByte := make([]byte, 2)
+	binary.LittleEndian.PutUint16(idByte, uint16(id))
 
 	client := &ClientWebsocket{
 		id:     id,
-		idByte: make([]byte, 2),
+		idByte: idByte,
 		conn:   conn,
 		room:   room,
 		send:   make(chan []byte),
 	}
-	client.idByte[0] = byte(id & 0xff)
-	client.idByte[1] = byte(id >> 8)
 
 	return client, err
 }

--- a/iguagile/websocket-client.go
+++ b/iguagile/websocket-client.go
@@ -74,6 +74,7 @@ func (c *ClientWebsocket) Send(message []byte) {
 	c.send <- message
 }
 
+// Close closes the connection.
 func (c *ClientWebsocket) Close() error {
 	return c.conn.Close()
 }

--- a/iguagile/websocket-client.go
+++ b/iguagile/websocket-client.go
@@ -2,6 +2,7 @@ package iguagile
 
 import (
 	"encoding/binary"
+
 	"github.com/gorilla/websocket"
 )
 

--- a/iguagile/websocket-client.go
+++ b/iguagile/websocket-client.go
@@ -2,8 +2,6 @@ package iguagile
 
 import (
 	"encoding/binary"
-	"time"
-
 	"github.com/gorilla/websocket"
 )
 
@@ -35,8 +33,29 @@ func NewClientWebsocket(room *Room, conn *websocket.Conn) (*ClientWebsocket, err
 
 // Run is provides backend synchronize goroutine.
 func (c *ClientWebsocket) Run() {
-	go c.readPump()
-	go c.writePump()
+	go func() {
+		for {
+			_, message, err := c.conn.ReadMessage()
+			if err != nil {
+				c.room.log.Println(err)
+				c.room.CloseConnection(c)
+				break
+			}
+
+			c.room.Receive(c, message)
+		}
+	}()
+
+	go func() {
+		for {
+			message := <-c.send
+			if err := c.conn.WriteMessage(websocket.BinaryMessage, message); err != nil {
+				c.room.log.Println(err)
+				c.room.CloseConnection(c)
+				break
+			}
+		}
+	}()
 }
 
 // GetID is getter for id
@@ -56,84 +75,4 @@ func (c *ClientWebsocket) Send(message []byte) {
 
 func (c *ClientWebsocket) Close() error {
 	return c.conn.Close()
-}
-
-// Copyright 2013 The Gorilla WebSocket Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// https://github.com/gorilla/websocket/blob/master/LICENSE
-
-func (c *ClientWebsocket) readPump() {
-	defer func() {
-		c.room.CloseConnection(c)
-	}()
-
-	c.conn.SetReadLimit(maxMessageSize)
-	if err := c.conn.SetReadDeadline(time.Now().Add(pongWait)); err != nil {
-		c.room.log.Println(err)
-	}
-
-	c.conn.SetPongHandler(func(string) error {
-		if err := c.conn.SetReadDeadline(time.Now().Add(pongWait)); err != nil {
-			c.room.log.Printf("error: %v", err)
-		}
-		return nil
-	})
-	for {
-		_, message, err := c.conn.ReadMessage()
-		if err != nil {
-			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
-				c.room.log.Printf("error: %v", err)
-			}
-			break
-		}
-
-		c.room.Receive(c, message)
-	}
-}
-
-func (c *ClientWebsocket) writePump() {
-	ticker := time.NewTicker(pingPeriod)
-	defer func() {
-		ticker.Stop()
-		c.room.CloseConnection(c)
-	}()
-	for {
-		select {
-		case message, ok := <-c.send:
-			if err := c.conn.SetWriteDeadline(time.Now().Add(writeWait)); err != nil {
-				c.room.log.Println(err)
-			}
-			if !ok {
-				// The room closed the channel.
-				if err := c.conn.WriteMessage(websocket.CloseMessage, []byte{}); err != nil {
-					c.room.log.Println(err)
-				}
-
-				return
-			}
-
-			w, err := c.conn.NextWriter(websocket.BinaryMessage)
-			if err != nil {
-				c.room.log.Println(err)
-				return
-			}
-
-			if _, err := w.Write(message); err != nil {
-				c.room.log.Println(err)
-			}
-
-			if err := w.Close(); err != nil {
-				c.room.log.Println(err)
-				return
-			}
-		case <-ticker.C:
-			if err := c.conn.SetWriteDeadline(time.Now().Add(writeWait)); err != nil {
-				c.room.log.Println(err)
-			}
-
-			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
-				return
-			}
-		}
-	}
 }


### PR DESCRIPTION
RoomとClientにCloseメソッドを追加
ClientのメソッドのSendAllClients, SendOtherClients, CloseConnectionをRoomのメソッドに変更
[]byteとintの変換をビット演算からbinaryパッケージの関数を使用するように変更
*ClientWebsocket.Runをリファクタリング