### PR TITLE
Add gameobject list

### DIFF
--- a/iguagile/gameobject.go
+++ b/iguagile/gameobject.go
@@ -1,5 +1,6 @@
 package iguagile
 
+// GameObject is object to be synchronized.
 type GameObject struct {
 	id    int
 	owner Client

--- a/iguagile/gameobject.go
+++ b/iguagile/gameobject.go
@@ -1,0 +1,6 @@
+package iguagile
+
+type GameObject struct {
+	id    int
+	owner Client
+}

--- a/iguagile/room.go
+++ b/iguagile/room.go
@@ -134,6 +134,7 @@ func (r *Room) Receive(sender Client, receivedData []byte) {
 	}
 }
 
+// ReceiveRPC receives rpc to server
 func (r *Room) ReceiveRPC(sender Client, binaryData *data.BinaryData) {
 	switch binaryData.MessageType {
 	case instantiate:
@@ -143,6 +144,7 @@ func (r *Room) ReceiveRPC(sender Client, binaryData *data.BinaryData) {
 	}
 }
 
+// InstantiateObject instantiates the game object
 func (r *Room) InstantiateObject(sender Client, idByte []byte) {
 	objID := int(binary.LittleEndian.Uint32(idByte))
 	if _, ok := r.objects[objID]; ok {
@@ -158,6 +160,7 @@ func (r *Room) InstantiateObject(sender Client, idByte []byte) {
 	r.SendToAllClients(message)
 }
 
+// DestroyObject destroys the game object
 func (r *Room) DestroyObject(sender Client, idByte []byte) {
 	objID := int(binary.LittleEndian.Uint32(idByte))
 	obj, ok := r.objects[objID]

--- a/iguagile/room.go
+++ b/iguagile/room.go
@@ -158,7 +158,7 @@ func (r *Room) ReceiveRPC(sender Client, binaryData *data.BinaryData) {
 		r.log.Println(binaryData)
 	}
 }
-q
+
 // InstantiateObject instantiates the game object
 func (r *Room) InstantiateObject(sender Client, idByte []byte) {
 	objID := int(binary.LittleEndian.Uint32(idByte))


### PR DESCRIPTION
同期するGameObjectをサーバ側で管理できるようにRoomにGameObjectのmapを追加
GameObjectの生成， 削除，操作権限の取得，譲渡ができるようにTargetにServerを追加
クライアント側で自分がhostであるか確認できるようにhostになったclientにhostになったことを通知する機能を追加