### PR TITLE
Check client exist

### DIFF
--- a/iguagile/room.go
+++ b/iguagile/room.go
@@ -239,6 +239,10 @@ func (r *Room) TransferObjectControlAuthority(sender Client, payload []byte) {
 	clientIDByte := payload[4:8]
 	clientID := int(binary.LittleEndian.Uint32(clientIDByte))
 
+	if _, ok := r.clients[clientID]; !ok {
+		return
+	}
+
 	obj, ok := r.objects[objID]
 	if !ok {
 		return


### PR DESCRIPTION
* TransferObjectControlAuthorityで存在しないidのclientに所有権を譲渡できてしまう問題を修正するため，clientの存在を確認するように変更
* client idからclientのポインタを取得できるようにclientsをmap[Client]boolからmap[int]Clientに変更