### PR TITLE
Fix bugs

### DIFF
--- a/iguagile/gameobject.go
+++ b/iguagile/gameobject.go
@@ -2,6 +2,7 @@ package iguagile
 
 // GameObject is object to be synchronized.
 type GameObject struct {
-	id    int
-	owner *Client
+	id           int
+	owner        *Client
+	resourcePath []byte
 }

--- a/iguagile/room.go
+++ b/iguagile/room.go
@@ -84,9 +84,10 @@ func (r *Room) Register(client *Client) {
 	r.buffer[&message] = client
 
 	for _, obj := range r.objects {
-		objectIDByte := make([]byte, 2)
-		binary.LittleEndian.PutUint16(objectIDByte, uint16(obj.id))
-		msg := append(append(obj.owner.GetIDByte(), instantiate), objectIDByte...)
+		objectIDByte := make([]byte, 4)
+		binary.LittleEndian.PutUint32(objectIDByte, uint32(obj.id))
+		payload := append(objectIDByte, obj.resourcePath...)
+		msg := append(append(obj.owner.GetIDByte(), instantiate), payload...)
 		client.Send(msg)
 	}
 
@@ -186,8 +187,9 @@ func (r *Room) InstantiateObject(sender *Client, data []byte) {
 	}
 
 	r.objects[objID] = &GameObject{
-		owner: sender,
-		id:    objID,
+		owner:        sender,
+		id:           objID,
+		resourcePath: data[4:],
 	}
 
 	message := append(append(sender.GetIDByte(), instantiate), data...)

--- a/iguagile/room.go
+++ b/iguagile/room.go
@@ -38,6 +38,7 @@ func NewRoom(serverID int, store Store) *Room {
 		id:        roomID,
 		clients:   make(map[int]*Client),
 		buffer:    make(map[*[]byte]*Client),
+		objects:   make(map[int]*GameObject),
 		generator: gen,
 		log:       log.New(os.Stdout, "iguagile-engine ", log.Lshortfile),
 	}
@@ -174,7 +175,7 @@ func (r *Room) ReceiveRPC(sender *Client, binaryData *data.BinaryData) {
 
 // InstantiateObject instantiates the game object.
 func (r *Room) InstantiateObject(sender *Client, data []byte) {
-	if len(data) >= 4 {
+	if len(data) <= 4 {
 		r.log.Println("invalid data length")
 		return
 	}


### PR DESCRIPTION
いくつかの不具合を修正。
* InstantiateObjectでのデータ長が4以下のときreturnするはずが4以上のときにreturnしていた。
* NewRoomでgame objectのmapを生成していなかったためInstantiateObjectでnilを参照してpanicする。
* Register送信するgame objectのidが32bitではなく16bitになっていた。
* Registerでgame objectをclientに送信するときに必要なresource pathが含まれていなかった。