### PR TITLE
Fix lock

### DIFF
--- a/fail_test.bash
+++ b/fail_test.bash
@@ -3,11 +3,12 @@
 cnt=0
 
 export REDIS_HOST=localhost:6379
+go test -v ./iguagile -count=1 -o iguagile-test
 
-for i in 1 2 3 4 5 6 7 8 9 10
+for i in {1..10}
 do
     echo "testing try... $i"
-    go test -v ./iguagile -count=1
+    ./iguagile-test
     res=$?
     if [[ ${res} -ne 0 ]]; then
         echo "test failed."

--- a/iguagile/gameobject.go
+++ b/iguagile/gameobject.go
@@ -35,9 +35,7 @@ func NewGameObjectManager() *GameObjectManager {
 
 // Get GameObject.
 func (m *GameObjectManager) Get(objectID int) (*GameObject, error) {
-	m.Lock()
 	gameObject, ok := m.gameObjects[objectID]
-	m.Unlock()
 	if !ok {
 		return nil, fmt.Errorf("object not exists %v", objectID)
 	}
@@ -47,9 +45,6 @@ func (m *GameObjectManager) Get(objectID int) (*GameObject, error) {
 
 // Add GameObject.
 func (m *GameObjectManager) Add(gameObject *GameObject) error {
-	m.Lock()
-	defer m.Unlock()
-
 	if _, ok := m.gameObjects[gameObject.id]; ok {
 		return fmt.Errorf("object exist %v", gameObject.id)
 	}
@@ -60,9 +55,6 @@ func (m *GameObjectManager) Add(gameObject *GameObject) error {
 
 // Remove GameObject.
 func (m *GameObjectManager) Remove(objectID int) {
-	m.Lock()
-	defer m.Unlock()
-
 	if _, ok := m.gameObjects[objectID]; !ok {
 		return
 	}
@@ -72,9 +64,7 @@ func (m *GameObjectManager) Remove(objectID int) {
 
 // Exist checks the GameObject exists.
 func (m *GameObjectManager) Exist(objectID int) bool {
-	m.Lock()
 	_, ok := m.gameObjects[objectID]
-	m.Unlock()
 	return ok
 }
 
@@ -85,7 +75,5 @@ func (m *GameObjectManager) GetAllGameObjects() map[int]*GameObject {
 
 // Clear all GameObjects.
 func (m *GameObjectManager) Clear() {
-	m.Lock()
 	m.gameObjects = make(map[int]*GameObject)
-	m.Unlock()
 }


### PR DESCRIPTION
* TransferObjectControlAuthorityの途中でDestroyObjectが呼ばれると正常に動作しなくなる可能性があったためロックの範囲を修正。
* テストにかかる時間を短縮するためテストを最初に一度のみコンパイルするように変更。